### PR TITLE
[issue #1] replace dozer mapper by mapstruct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ dist
 # TernJS port file
 .tern-port
 
+.angular/
 
 ##############################
 ## Java

--- a/back/pom.xml
+++ b/back/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.4</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.hakkou.mock</groupId>
@@ -14,7 +14,9 @@
 	<name>boats</name>
 	<description>Mock boat projects</description>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>18</java.version>
+		<org.mapstruct.version>1.6.0.Beta2</org.mapstruct.version>
+		<lombok.version>1.18.28</lombok.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -25,23 +27,39 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
+			<optional>true</optional>
+			<scope>provided</scope>
+		</dependency>
 		
 		<dependency>
 			<groupId>net.sf.dozer</groupId>
 			<artifactId>dozer</artifactId>
 			<version>5.5.1</version>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${org.mapstruct.version}</version> 
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
+		</dependency>		
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -63,6 +81,28 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${org.mapstruct.version}</version>
+						</path>						
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+
 		</plugins>
 	</build>
 

--- a/back/src/main/java/org/hakkou/mock/boats/controller/BoatController.java
+++ b/back/src/main/java/org/hakkou/mock/boats/controller/BoatController.java
@@ -3,8 +3,10 @@ package org.hakkou.mock.boats.controller;
 import java.util.List;
 
 import org.hakkou.mock.boats.dto.BoatDto;
+import org.hakkou.mock.boats.exceptions.BoatException;
 import org.hakkou.mock.boats.service.management.BoatManagement;
-import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,13 +16,17 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import lombok.AllArgsConstructor;
 
 @RestController
 @RequestMapping("boats")
 @CrossOrigin
+@AllArgsConstructor
 public class BoatController {
-    @Autowired
-    private BoatManagement boatService;
+    
+    private final BoatManagement boatService;
 
     @GetMapping("/read/all")
     public List<BoatDto> getAllBoats() {
@@ -29,12 +35,20 @@ public class BoatController {
 
     @DeleteMapping("/delete/{id}")
     public void deleteBoat(@PathVariable Long id) {
-        boatService.deleteBoat(id);
+        try {
+            boatService.deleteBoat(id);
+        } catch (BoatException bex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,bex.getMessage());
+        }
     }
 
     @GetMapping("/read/{id}")
     public BoatDto getById(@PathVariable Long id) {
-        return boatService.getBoat(id);
+        try {
+            return boatService.getBoat(id);
+        } catch (BoatException bex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,bex.getMessage());
+        }
     }
 
     @PostMapping("/create")
@@ -47,13 +61,12 @@ public class BoatController {
     }
 
     @PutMapping("/update")
-    public BoatDto updateBoat(@RequestBody BoatDto boat){
-        if(!boatService.boatExists(boat.getId())) {
-            //TODO add exception handling
-            return null;
-        } else {
-            return boatService.saveBoat(boat);
-        }
+    public BoatDto updateBoat(@RequestBody BoatDto boat) {
+       try {
+        return boatService.updateBoat(boat);
+       } catch (BoatException bex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,bex.getMessage());
+       }
     }
 
 }

--- a/back/src/main/java/org/hakkou/mock/boats/controller/BoatController.java
+++ b/back/src/main/java/org/hakkou/mock/boats/controller/BoatController.java
@@ -38,7 +38,7 @@ public class BoatController {
         try {
             boatService.deleteBoat(id);
         } catch (BoatException bex) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,bex.getMessage());
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, bex.getMessage());
         }
     }
 
@@ -47,16 +47,16 @@ public class BoatController {
         try {
             return boatService.getBoat(id);
         } catch (BoatException bex) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,bex.getMessage());
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, bex.getMessage());
         }
     }
 
     @PostMapping("/create")
     public BoatDto addBoat(@RequestBody  BoatDto boat) {
-        if(boat.getId() != null) {            
-            return null;
-        } else {
-            return boatService.saveBoat(boat);
+        try {
+            return boatService.addBoat(boat);
+        } catch (BoatException bex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, bex.getMessage());
         }
     }
 
@@ -65,7 +65,7 @@ public class BoatController {
        try {
         return boatService.updateBoat(boat);
        } catch (BoatException bex) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,bex.getMessage());
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, bex.getMessage());
        }
     }
 

--- a/back/src/main/java/org/hakkou/mock/boats/dto/BoatDto.java
+++ b/back/src/main/java/org/hakkou/mock/boats/dto/BoatDto.java
@@ -1,5 +1,7 @@
 package org.hakkou.mock.boats.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,6 +9,8 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 public class BoatDto {
     private Long id;
     private String name;

--- a/back/src/main/java/org/hakkou/mock/boats/exceptions/BoatException.java
+++ b/back/src/main/java/org/hakkou/mock/boats/exceptions/BoatException.java
@@ -1,0 +1,7 @@
+package org.hakkou.mock.boats.exceptions;
+
+public class BoatException extends Exception {
+    public BoatException(String message) {
+        super(message);
+    }
+}

--- a/back/src/main/java/org/hakkou/mock/boats/mappers/BoatMapper.java
+++ b/back/src/main/java/org/hakkou/mock/boats/mappers/BoatMapper.java
@@ -1,0 +1,19 @@
+package org.hakkou.mock.boats.mappers;
+
+import org.hakkou.mock.boats.dto.BoatDto;
+import org.hakkou.mock.boats.model.Boat;
+import org.mapstruct.Mapper;
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BoatMapper {
+
+    BoatDto entityToDto(Boat boat);
+
+    Boat dtoToEntity(BoatDto boatDto);
+
+    List<BoatDto> listEntitiesIntoDtos(List<Boat> boats);
+
+    List<Boat> listDtosIntoEntities(List<BoatDto> boatDtos);
+
+}

--- a/back/src/main/java/org/hakkou/mock/boats/model/Boat.java
+++ b/back/src/main/java/org/hakkou/mock/boats/model/Boat.java
@@ -7,6 +7,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,6 +18,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Boat {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/back/src/main/java/org/hakkou/mock/boats/service/BoatService.java
+++ b/back/src/main/java/org/hakkou/mock/boats/service/BoatService.java
@@ -32,8 +32,13 @@ public class BoatService implements BoatManagement {
         return boatMapper.listEntitiesIntoDtos(boatRepo.findAll());
     }
 
-    public BoatDto saveBoat(BoatDto boat) {
+    public BoatDto addBoat(BoatDto boat) throws BoatException{
         Boat entityToSave = boatMapper.dtoToEntity(boat);
+        if(entityToSave.getId() != null) {
+            throw new BoatException("Boat with id : "  
+            + entityToSave.getId() + 
+            " already exists, wont add");
+        }
         return boatMapper.entityToDto(boatRepo.save(entityToSave));
     }
 
@@ -47,15 +52,14 @@ public class BoatService implements BoatManagement {
     }
     
     public BoatDto updateBoat(BoatDto boatDto) throws BoatException {
-        if(boatExists(boatDto.getId())) {
+        if(boatDto.getId() == null) {
+            throw new BoatException("id not provided for boat to update");
+        }
+        Optional<Boat> boatToUpdate = boatRepo.findById(boatDto.getId());
+        if(boatToUpdate.isPresent()) {
             return boatMapper.entityToDto(boatRepo.save(boatMapper.dtoToEntity(boatDto)));
         } else {
             throw new BoatException("not found, cannot update");
         }
     }
-
-    private boolean boatExists(Long id) {
-        return boatRepo.existsById(id);
-    }
-
 }

--- a/back/src/main/java/org/hakkou/mock/boats/service/management/BoatManagement.java
+++ b/back/src/main/java/org/hakkou/mock/boats/service/management/BoatManagement.java
@@ -10,7 +10,7 @@ public interface BoatManagement {
 
     public BoatDto getBoat(Long id) throws BoatException;
 
-    public BoatDto saveBoat(BoatDto boat);
+    public BoatDto addBoat(BoatDto boat) throws BoatException;
 
     public void deleteBoat(Long id) throws BoatException;
 

--- a/back/src/main/java/org/hakkou/mock/boats/service/management/BoatManagement.java
+++ b/back/src/main/java/org/hakkou/mock/boats/service/management/BoatManagement.java
@@ -3,15 +3,16 @@ package org.hakkou.mock.boats.service.management;
 import java.util.List;
 
 import org.hakkou.mock.boats.dto.BoatDto;
+import org.hakkou.mock.boats.exceptions.BoatException;
 
 public interface BoatManagement {
     public List<BoatDto> getAllBoats();
 
-    public BoatDto getBoat(Long id);
+    public BoatDto getBoat(Long id) throws BoatException;
 
     public BoatDto saveBoat(BoatDto boat);
 
-    public void deleteBoat(Long id);
+    public void deleteBoat(Long id) throws BoatException;
 
-    public boolean boatExists(Long id);
+    public BoatDto updateBoat(BoatDto boat) throws BoatException;
 }

--- a/back/src/test/java/org/hakkou/mock/boats/mappers/BoatMapperTest.java
+++ b/back/src/test/java/org/hakkou/mock/boats/mappers/BoatMapperTest.java
@@ -1,0 +1,63 @@
+package org.hakkou.mock.boats.mappers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hakkou.mock.boats.dto.BoatDto;
+import org.hakkou.mock.boats.model.Boat;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BoatMapperTest {
+    private BoatMapper boatMapper = new BoatMapperImpl();
+
+    @Test
+    public void entityMapsToDto() {
+        Boat boat = Boat.builder().id(1L).name("single").description("single boat").build();
+        BoatDto boatDto = boatMapper.entityToDto(boat);
+        Assertions.assertEquals(1L, boatDto.getId());
+        Assertions.assertEquals("single", boatDto.getName());
+        Assertions.assertEquals("single boat", boatDto.getDescription());
+
+
+    }
+
+    @Test
+    public void dtoMapsToEntity() {
+        BoatDto boatDto = BoatDto.builder().id(1L).name("single").description("single boat").build();
+        Boat boat = boatMapper.dtoToEntity(boatDto);
+        Assertions.assertEquals(1L, boat.getId());
+        Assertions.assertEquals("single", boat.getName());
+        Assertions.assertEquals("single boat", boat.getDescription());        
+    }
+
+    @Test
+    public void entityListMapsToDtoList() {
+        List<Boat> boats = Arrays.asList(
+            Boat.builder().id(1L).name("first").description("first boat").build(),
+            Boat.builder().id(2L).name("second").description("second boat").build()
+        );
+
+        List<BoatDto> boatDtos = boatMapper.listEntitiesIntoDtos(boats);
+
+        Assertions.assertEquals(2, boatDtos.size());
+        Assertions.assertEquals(1L, boatDtos.get(0).getId());
+        Assertions.assertEquals("second", boatDtos.get(1).getName());
+        Assertions.assertEquals("first boat", boatDtos.get(0).getDescription());
+    }
+
+    @Test
+    public void dtoListMapsToEntitList() {
+        List<BoatDto> boatsDtos = Arrays.asList(
+            BoatDto.builder().id(1L).name("first").description("first boat").build(),
+            BoatDto.builder().id(2L).name("second").description("second boat").build()
+        );
+
+        List<Boat> boats = boatMapper.listDtosIntoEntities(boatsDtos);
+
+        Assertions.assertEquals(2, boats.size());
+        Assertions.assertEquals(1L, boats.get(0).getId());
+        Assertions.assertEquals("second", boats.get(1).getName());
+        Assertions.assertEquals("first boat", boats.get(0).getDescription());
+    }
+}

--- a/back/src/test/java/org/hakkou/mock/boats/service/BoatServiceTest.java
+++ b/back/src/test/java/org/hakkou/mock/boats/service/BoatServiceTest.java
@@ -4,15 +4,18 @@ import org.hakkou.mock.boats.repo.BoatRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Optional;
 
 import org.hakkou.mock.boats.dto.BoatDto;
@@ -26,45 +29,100 @@ public class BoatServiceTest {
     @Mock
     private BoatRepository boatRepo;
     
-    @Spy
+    @Mock
     private BoatMapperImpl boatMapper;
     
+    @InjectMocks
     private BoatService boatService;
 
+    private List<Boat> mockedBoats = new ArrayList<>(Arrays.asList(
+        Boat.builder().id(1L).name("first").description("first boat").build(),
+        Boat.builder().id(2L).name("second").description("second boat").build()
+    ));
+
     @Test
-    public void mapping_applies_whenread_methods_called() {
-        // GIVEN
-        boatService = new BoatService(boatMapper, boatRepo);
-        List<Boat> boats = Arrays.asList(
-            Boat.builder().id(1L).name("first").description("first boat").build(),
-            Boat.builder().id(2L).name("second").description("second boat").build()
-        );
-        when(boatRepo.findAll()).thenReturn(boats);
-        when(boatRepo.findById(anyLong())).thenAnswer(invoke -> getFromMock(invoke.getArgument(0), boats));
+    public void getAllBoatsCallsFindAllInRepo() {        
 
         // WHEN
-        List<BoatDto> requestedBoats = boatService.getAllBoats();
-        try {
-            BoatDto requestedBoat = boatService.getBoat(2L);
-            //THEN
-            Assertions.assertEquals(2, requestedBoats.size());
-            Assertions.assertEquals(1L, requestedBoats.get(0).getId());
-            Assertions.assertEquals("first", requestedBoats.get(0).getName());
-            Assertions.assertEquals("first boat", requestedBoats.get(0).getDescription());
-            Assertions.assertEquals(2L, requestedBoat.getId());
-        } catch (BoatException ex) {
-            Assertions.assertTrue(false);
-        }
-        Assertions.assertThrows(BoatException.class, () -> {
-            boatService.getBoat(3L);
-        
-        });      
-        
+       boatService.getAllBoats();
 
+        //THEN
+        verify(boatRepo).findAll();
     }
 
-    private Optional<Boat> getFromMock(Long id, List<Boat> boats) {
-        return boats.stream().filter(b -> b.getId().equals(id)).findFirst();
+
+    @Test
+    public void exception_handled_when_getBoat_called() {    
+        when(boatRepo.findById(anyLong())).thenAnswer(invoke -> getFromMock(invoke.getArgument(0)));    
+
+        Assertions.assertDoesNotThrow(() -> {
+            boatService.getBoat(1L);
+        });
+        Assertions.assertThrows(BoatException.class, () -> {
+            boatService.getBoat(3L);        
+        });
+    }
+
+    private Optional<Boat> getFromMock(Long id) {
+        return mockedBoats.stream().filter(b -> b.getId().equals(id)).findFirst();
     }
     
+    @Test
+    public void exception_handled_when_addBoat_called() {
+        // GIVEN 
+        when(boatRepo.save(any(Boat.class))).thenAnswer(invoke -> saveInMock(invoke.getArgument(0)));        
+        when(boatMapper.dtoToEntity(any(BoatDto.class))).thenCallRealMethod();
+        // WHEN / THEN
+        try {
+            boatService.addBoat(BoatDto.builder()
+                .id(null)
+                .name("added")
+                .description("added boat")
+            .build());
+            Assertions.assertEquals(3, mockedBoats.size());
+            Assertions.assertEquals(3L, mockedBoats.get(2).getId());
+            Assertions.assertEquals("added", mockedBoats.get(2).getName());
+            Assertions.assertEquals("added boat", mockedBoats.get(2).getDescription());
+        } catch (Exception ex) {
+            Assertions.assertTrue(false);
+        }
+
+        // throws exception if boat added has an id
+        Assertions.assertThrows(BoatException.class, () -> {
+            boatService.addBoat(BoatDto.builder()
+                .id(1L)
+                .name("added")
+                .description("added boat")
+            .build());
+        });
+    }
+
+    private Boat saveInMock(Boat boatToSave) {
+        getFromMock(boatToSave.getId()).ifPresentOrElse(b -> {
+            b.setName(boatToSave.getName());
+            b.setDescription(boatToSave.getDescription());          
+        }, () -> {
+            boatToSave.setId(Long.valueOf(mockedBoats.size() + 1));
+            mockedBoats.add(boatToSave);
+        });
+        return boatToSave;
+    }
+
+    @Test
+    public void exception_handled_when_deleteBoat_called() {
+        // GIVEN         
+        when(boatRepo.findById(anyLong())).thenAnswer(invoke -> getFromMock(invoke.getArgument(0)));
+        
+        // WHEN / THEN
+        Assertions.assertThrows(BoatException.class, () -> {
+            boatService.deleteBoat(3L);
+        });
+        try {
+            boatService.deleteBoat(1L);
+            // THEN
+            verify(boatRepo).deleteById(1L);
+        } catch (Exception ex ) {
+            Assertions.assertTrue(false);
+        }
+    }
 }

--- a/back/src/test/java/org/hakkou/mock/boats/service/BoatServiceTest.java
+++ b/back/src/test/java/org/hakkou/mock/boats/service/BoatServiceTest.java
@@ -1,0 +1,70 @@
+package org.hakkou.mock.boats.service;
+
+import org.hakkou.mock.boats.repo.BoatRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hakkou.mock.boats.dto.BoatDto;
+import org.hakkou.mock.boats.exceptions.BoatException;
+import org.hakkou.mock.boats.model.Boat;
+import org.hakkou.mock.boats.mappers.BoatMapperImpl;
+
+@ExtendWith(MockitoExtension.class)
+public class BoatServiceTest {
+
+    @Mock
+    private BoatRepository boatRepo;
+    
+    @Spy
+    private BoatMapperImpl boatMapper;
+    
+    private BoatService boatService;
+
+    @Test
+    public void mapping_applies_whenread_methods_called() {
+        // GIVEN
+        boatService = new BoatService(boatMapper, boatRepo);
+        List<Boat> boats = Arrays.asList(
+            Boat.builder().id(1L).name("first").description("first boat").build(),
+            Boat.builder().id(2L).name("second").description("second boat").build()
+        );
+        when(boatRepo.findAll()).thenReturn(boats);
+        when(boatRepo.findById(anyLong())).thenAnswer(invoke -> getFromMock(invoke.getArgument(0), boats));
+
+        // WHEN
+        List<BoatDto> requestedBoats = boatService.getAllBoats();
+        try {
+            BoatDto requestedBoat = boatService.getBoat(2L);
+            //THEN
+            Assertions.assertEquals(2, requestedBoats.size());
+            Assertions.assertEquals(1L, requestedBoats.get(0).getId());
+            Assertions.assertEquals("first", requestedBoats.get(0).getName());
+            Assertions.assertEquals("first boat", requestedBoats.get(0).getDescription());
+            Assertions.assertEquals(2L, requestedBoat.getId());
+        } catch (BoatException ex) {
+            Assertions.assertTrue(false);
+        }
+        Assertions.assertThrows(BoatException.class, () -> {
+            boatService.getBoat(3L);
+        
+        });      
+        
+
+    }
+
+    private Optional<Boat> getFromMock(Long id, List<Boat> boats) {
+        return boats.stream().filter(b -> b.getId().equals(id)).findFirst();
+    }
+    
+}

--- a/back/src/test/java/org/hakkou/mock/boats/utils/MapUtilsTest.java
+++ b/back/src/test/java/org/hakkou/mock/boats/utils/MapUtilsTest.java
@@ -1,14 +1,14 @@
+package org.hakkou.mock.boats.utils;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.dozer.DozerBeanMapper;
 import org.dozer.Mapper;
 import org.hakkou.mock.boats.dto.BoatDto;
 import org.hakkou.mock.boats.model.Boat;
-import org.hakkou.mock.boats.utils.MapUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class MapperTest {
+public class MapUtilsTest {
     
     
     private static Mapper dozerMapper;


### PR DESCRIPTION
code has been a little beautified. Dozer dependencw has been kept because it could be useful for generic mappings if needed.